### PR TITLE
[1.4.7] Inflate downloaded files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,3 +127,6 @@ configurations.all {
         force 'org.codehaus.groovy:groovy-all:2.4.12'
     }
 }
+
+//Can you believe it, tests designed for loom are broken when ran with voldeloom.
+test.onlyIf { project.hasProperty("yes-i-really-wanna-run-tests") }

--- a/src/main/java/net/fabricmc/loom/util/DownloadUtil.java
+++ b/src/main/java/net/fabricmc/loom/util/DownloadUtil.java
@@ -26,9 +26,11 @@ package net.fabricmc.loom.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
 
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
@@ -105,7 +107,13 @@ public class DownloadUtil {
 		}
 
 		try { //Try download to the output
-			FileUtils.copyInputStreamToFile(connection.getInputStream(), to);
+			InputStream inputStream = connection.getInputStream();
+
+			if("gzip".equals(connection.getContentEncoding())) {
+				inputStream = new GZIPInputStream(inputStream);
+			}
+
+			FileUtils.copyInputStreamToFile(inputStream, to);
 		} catch (IOException e) {
 			to.delete(); //Probably isn't good if it fails to copy/save
 			throw e;


### PR DESCRIPTION
Loom's `DownloadUtil.downloadIfChanged` method has historically always passed an `Accept-Encoding: gzip` header, but had no functionality to inflate the files if gzipped encoding was actually used. For the longest time Mojang's servers did not serve gzipped files so this never cropped up in practice. But these days they do, so Voldeloom would download stuff like `version_manifest.json` as a gzipped file, not inflate it, then try to parse it as JSON with the expected results.

This was fixed in fabric-loom by modmuss50 in https://github.com/FabricMC/fabric-loom/commit/34b771f7447b181c27f7127ec77fda6eb465111a, I just lazily cherry-picked that implementation. (`HashedDownloadUtil` must have been added some time between the Voldeloom branch point and that commit. because I can't find it.)

This won't affect you if you already have the correct files in your Gradle cache, but it does affect new people setting up projects (hi).

I also yeeted the tests because they fail on my machine and I tried `-Dskip.tests=true` but it no worky, and it was blocking publishToMavenLocal. They were designed for fabric 1.14 anyway, no way in hell that they work.