### PR TITLE
[1.4.7] Hack fix for Gradle 7

### DIFF
--- a/src/main/java/net/fabricmc/loom/providers/MinecraftLibraryProvider.java
+++ b/src/main/java/net/fabricmc/loom/providers/MinecraftLibraryProvider.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 
+import net.fabricmc.loom.AbstractPlugin;
 import org.gradle.api.Project;
 
 import net.fabricmc.loom.LoomGradleExtension;
@@ -59,10 +60,10 @@ public class MinecraftLibraryProvider {
 
 				project.getDependencies().add(Constants.MINECRAFT_DEPENDENCIES, project.getDependencies().module(library.getArtifactName()));
 				// voldeloom: add loader's dependencies. versions this old simply do not depend on these.
-				project.getDependencies().add("runtime", project.getDependencies().module("org.apache.logging.log4j:log4j-core:2.8.1"));
-				project.getDependencies().add("runtime", project.getDependencies().module("org.apache.logging.log4j:log4j-api:2.8.1"));
-				project.getDependencies().add("runtime", project.getDependencies().module("com.google.code.gson:gson:2.8.6"));
-				project.getDependencies().add("runtime", project.getDependencies().module("com.google.guava:guava:28.0-jre"));
+				project.getDependencies().add(AbstractPlugin.runtimeOrRuntimeOnly, project.getDependencies().module("org.apache.logging.log4j:log4j-core:2.8.1"));
+				project.getDependencies().add(AbstractPlugin.runtimeOrRuntimeOnly, project.getDependencies().module("org.apache.logging.log4j:log4j-api:2.8.1"));
+				project.getDependencies().add(AbstractPlugin.runtimeOrRuntimeOnly, project.getDependencies().module("com.google.code.gson:gson:2.8.6"));
+				project.getDependencies().add(AbstractPlugin.runtimeOrRuntimeOnly, project.getDependencies().module("com.google.guava:guava:28.0-jre"));
 			}
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/util/RemappedConfigurationEntry.java
+++ b/src/main/java/net/fabricmc/loom/util/RemappedConfigurationEntry.java
@@ -24,6 +24,7 @@
 
 package net.fabricmc.loom.util;
 
+import net.fabricmc.loom.AbstractPlugin;
 import org.gradle.api.artifacts.ConfigurationContainer;
 
 public class RemappedConfigurationEntry {
@@ -61,7 +62,7 @@ public class RemappedConfigurationEntry {
 
 	public String getTargetConfiguration(ConfigurationContainer container) {
 		if (container.findByName(targetConfiguration) == null) {
-			return "compile";
+			return AbstractPlugin.compileOrImplementation;
 		}
 
 		return targetConfiguration;


### PR DESCRIPTION
This makes applying the plugin not instantly kaboom on Gradle 7 due to the Very Useful `compile` -> `implementation` and `runtime` -> `runtimeOnly` change. It still works on Gradle 4.

This *doesn't* fix how Gradle versions past 6 (maybe past 5) can't seem to resolve the Forge dependency correctly. I'll get a stacktrace and try to debug it when I'm not under the forgejam deadline lol but it's workaroundable by providing forge as a local file like this https://github.com/quat1024/hoppers/commit/6e2e3a124674db806aa16d361e0b46d32ec6d101

You may need to remove the project's `.gradle/loom-cache` after changing versions, I had some really weird to debug error that was resolved by deleting that folder.